### PR TITLE
Add optional Supabase auth headers and align redeem payload

### DIFF
--- a/src/api/permission.js
+++ b/src/api/permission.js
@@ -6,7 +6,9 @@ import {
   LICENSE_STATUS_URL,
   CHECKOUT_LOOKUP_URL,
   REDEEM_AUTH_HEADER_KEY,
-  REDEEM_AUTH_HEADER_VALUE
+  REDEEM_AUTH_HEADER_VALUE,
+  REDEEM_AUTH_HEADER_2_KEY,
+  REDEEM_AUTH_HEADER_2_VALUE
 } from '@/service/constants'
 
 // ---- Supabase wrappers (novo fluxo) ----
@@ -19,6 +21,9 @@ export async function redeemCode({ code, whatsapp, email }) {
   const headers = { 'Content-Type': 'application/json' }
   if (REDEEM_AUTH_HEADER_KEY && REDEEM_AUTH_HEADER_VALUE) {
     headers[REDEEM_AUTH_HEADER_KEY] = REDEEM_AUTH_HEADER_VALUE
+  }
+  if (REDEEM_AUTH_HEADER_2_KEY && REDEEM_AUTH_HEADER_2_VALUE) {
+    headers[REDEEM_AUTH_HEADER_2_KEY] = REDEEM_AUTH_HEADER_2_VALUE
   }
 
   const r = await fetch(REDEEM_URL, {

--- a/src/service/constants.js
+++ b/src/service/constants.js
@@ -63,5 +63,9 @@ export const REDEEM_TRY_BOTH = true        // tentar original e, se falhar, norm
 
 // ===== Auth opcional para Edge Function (deixe vazio se público) =====
 // Ex.: 'Authorization' / 'apikey'
-export const REDEEM_AUTH_HEADER_KEY = ''
-export const REDEEM_AUTH_HEADER_VALUE = ''
+export const REDEEM_AUTH_HEADER_KEY = 'Authorization'   // ou '' para desativado
+export const REDEEM_AUTH_HEADER_VALUE = ''                 // ex.: 'Bearer <SUPABASE_ANON_KEY>'
+
+// (opcional) segundo header, se o gateway exigir 'apikey'
+export const REDEEM_AUTH_HEADER_2_KEY = 'apikey'         // ou ''
+export const REDEEM_AUTH_HEADER_2_VALUE = ''             // ou ''


### PR DESCRIPTION
## Summary
- add configurable Authorization and apikey constants for Supabase edge function calls
- include optional auth headers in redeemCode fetch requests
- ensure redeem payload uses whatsapp_number and return status from Supabase response

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d49c99b3d48324b21c2482f9e9a333