### PR TITLE
Ensure Supabase activation flips popup to Pro immediately

### DIFF
--- a/src/components/common/ActiveCodeDialog.vue
+++ b/src/components/common/ActiveCodeDialog.vue
@@ -141,19 +141,25 @@ export default {
           }
 
           // ===== Bridge de compat p/ UI antiga: garantir "Pro" imediato =====
-          const legacyPermission =
-            data?.permissionInfo || {
-              status: 'active',
+          const legacyPermission = {
+            ...(data?.permissionInfo || {
               source: 'supabase',
               transaction_id: data?.transaction_id ?? null,
               plink_id: data?.plink_id ?? null,
               activated_at: Date.now()
-            }
+            }),
+            status: 'active'
+          }
 
           const whatsappNumber = (userPhoneNum || '').replace?.(/\D/g, '') || null
 
+          const licensePayload = {
+            ...data,
+            status: 'active'
+          }
+
           await chrome.storage?.local?.set?.({
-            [STORAGE_LICENSE_KEY]: data, // ex.: myapp_license
+            [STORAGE_LICENSE_KEY]: licensePayload, // ex.: myapp_license
             [STORAGE_ACTIVATION_FLAG]: true, // ex.: myapp_activation
             paid_mark: true, // flag lida pelo header para exibir "Pro"
             permissionInfo: legacyPermission // objeto mínimo p/ telas legadas
@@ -169,12 +175,8 @@ export default {
 
           // notificar UI e fechar
           // fallback para fluxo Supabase: força header/gates a virarem Pro
-          this.$emit(
-            'changePermissionCode',
-            legacyPermission?.plink_id ?? 'supabase_pro',
-            legacyPermission?.transaction_id ?? null,
-            whatsappNumber
-          )
+          console.log('[SUPA] redeem ok → flip to Pro', { license: licensePayload })
+          this.$emit('changePermissionCode', 'supabase_pro', null, whatsappNumber)
 
           this.languageVal = ''
           this.$message?.success?.('Ativado')


### PR DESCRIPTION
## Summary
- guarantee Supabase redemption stores an active status and always emits the supabase_pro permission change event
- centralize Supabase activation checks in the popup to force Pro headers during bootstrap and runtime updates
- surface Supabase license details in the user profile modal, including a fallback license when only activation flags exist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db2ea11f8083249fc1a677294f1e6e